### PR TITLE
Allow to give location hints.

### DIFF
--- a/app/controllers/location.rb
+++ b/app/controllers/location.rb
@@ -21,10 +21,14 @@ HasBeen.controllers do
     halt 404 unless defined? username
     @traveller = Travellers.find(username)
     halt 404 if @traveller.nil?
-    @location = escape_html(params[:location].force_encoding("UTF-8"))
-    if @traveller.hasbeen_in?(@location)
+
+    location = escape_html(params[:location].force_encoding("UTF-8"))
+
+    if @traveller.hasbeen_in?(location)
+      @location = @traveller.find_location(location)
       @verb = "has"
     else
+      @location = Location.new(location)
       @verb = "hasn't"
       status 404
     end

--- a/app/views/layouts/application.erb
+++ b/app/views/layouts/application.erb
@@ -6,7 +6,7 @@
     <%= javascript_include_tag 'hasbeen' %>
     <%= javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=AIzaSyAaMSg6gwxHyX9_dRb--bqCGKzeC6AS0yU&sensor=false" %>
   </head>
-  <body onload="goto('<%= @location %>')">
+  <body onload="goto('<%= (@location.hint || @location) unless @location.nil? %>')">
     <%= yield %>
   </body>
 </html>

--- a/config/travellers/bascht.yml
+++ b/config/travellers/bascht.yml
@@ -24,3 +24,4 @@ hasbeen:
     - "Gran Canaria"
     - "Brussels"
     - "Amsterdam"
+    - {"Amerika": "Amerika, Penig, Deutschland"}

--- a/lib/location.rb
+++ b/lib/location.rb
@@ -1,0 +1,3 @@
+class Location < String
+  attr_accessor :hint
+end

--- a/lib/traveller.rb
+++ b/lib/traveller.rb
@@ -7,7 +7,15 @@ require 'yaml'
 class Traveller < OpenStruct
   def locations
     unless self.hasbeen["cities"].nil?
-      self.hasbeen["cities"]
+      self.hasbeen["cities"].collect do |city|
+        if city.kind_of? Hash
+          location = Location.new(city.keys.first)
+          location.hint = String.new(city.values.first)
+        else
+          location = Location.new(city.to_s)
+        end
+        location
+      end
     else
       [] 
     end
@@ -17,6 +25,10 @@ class Traveller < OpenStruct
     self.locations.any?{ |location| 
       location.casecmp(place) == 0 
     }
+  end
+
+  def find_location(location)
+    self.locations.grep(location).first
   end
 
   def gravatar

--- a/spec/app/controllers/location_controller_spec.rb
+++ b/spec/app/controllers/location_controller_spec.rb
@@ -28,7 +28,7 @@ describe "Profiles" do
     page.should have_content "Bascht"
     click_link("Bascht")
     page.status_code.should == 200
-    page.should have_content "Bascht has been in Leipzig, Hamburg, Oelsnitz, Bangkok and Shanghai."
+    page.should have_content "Bascht has been in Leipzig, Hamburg, Oelsnitz, Bangkok, Shanghai and Amerika."
     current_url.should == "http://bascht.hasbeen.test/"
   end
 
@@ -37,8 +37,21 @@ describe "Profiles" do
     click_link("Leipzig")
     page.status_code.should == 200
     page.should have_content "Bascht has been in Leipzig."
+    page.should have_xpath('/html/body[@onload]')
+    page.should have_xpath('/html/body[@onload="goto(\'Leipzig\')"]')
     current_url.should == "http://bascht.hasbeen.test/Leipzig"
   end
+
+  it "should allow hinting to the correct places" do
+    visit_profile "bascht"
+    click_link("Amerika")
+    page.status_code.should == 200
+    page.should have_content "Bascht has been in Amerika."
+    page.should have_xpath('/html/body[@onload]')
+    page.should have_xpath('/html/body[@onload="goto(\'Amerika, Penig, Deutschland\')"]')
+    current_url.should == "http://bascht.hasbeen.test/Amerika"
+  end
+
 
   it "should take care of unicode" do
     visit_profile "bjoern"
@@ -56,6 +69,7 @@ describe "Locations" do
     visit_profile "bascht", "Hierwarnochkeinschwein"
     page.status_code.should == 404
     page.should have_content "Bascht hasn't been in Hierwarnochkeinschwein."
+    page.should have_xpath('/html/body[@onload="goto(\'Hierwarnochkeinschwein\')"]')
   end
 end
 

--- a/spec/files/bascht.yml
+++ b/spec/files/bascht.yml
@@ -10,3 +10,4 @@ hasbeen:
     - "Oelsnitz"
     - "Bangkok"
     - "Shanghai"
+    - "Amerika": "Amerika, Penig, Deutschland"

--- a/spec/traveller/traveller_spec.rb
+++ b/spec/traveller/traveller_spec.rb
@@ -3,6 +3,7 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper.rb')
 describe "A traveller" do
 
   let(:traveller) { traveller = Travellers.find("Bascht") }
+  let(:amerika)   { traveller.find_location("Amerika") }
 
   it "should initialize with a name and some Properties" do
     traveller.name.should == "Bascht"
@@ -15,14 +16,22 @@ describe "A traveller" do
   end
 
   it "should have been to some location" do
-    traveller.locations.count.should == 5
+    traveller.locations.count.should == 6
     traveller.locations.should == [ 
       "Leipzig", 
       "Hamburg", 
       "Oelsnitz", 
       "Bangkok", 
-      "Shanghai" 
+      "Shanghai",
+      "Amerika"
     ]
+  end
+
+  # Yep, Amerika is a part of a small town in saxony.
+  it "should allow to give hints" do
+    traveller.hasbeen_in?("Amerika").should == true
+    amerika.should == "Amerika"
+    amerika.hint.should == "Amerika, Penig, Deutschland"
   end
 
   it "should know where it has been" do


### PR DESCRIPTION
This refs #3 and I am pretty sure this will please both sides.
Hints can be given via YAML's key/value syntax in the city list, all
Other values will be parsed as a string, like before. E.g.:

``` yaml
cities:
  - "Livingstone"                           # "Livingstone"
  - {"Livingstone" : "Livingstone, Zambia"} # "Livingstone, Zambia"
```
