### PR TITLE
cache geodata on server using padrino cache

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,3 +27,4 @@ end
 # Padrino Stable Gem
 gem 'padrino', '0.12.0'
 gem 'json', '~> 1.8.1'
+gem 'google_maps_geocoder', '~> 0.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,10 @@ GEM
     diff-lcs (1.2.5)
     eventmachine (1.0.3)
     fakeweb (1.3.0)
-    http_router (0.11.1)
+    google_maps_geocoder (0.3.0)
+      activesupport
+      rack
+    http_router (0.11.0)
       rack (>= 1.0.0)
       url_mount (~> 0.2.1)
     i18n (0.6.9)
@@ -109,6 +112,7 @@ DEPENDENCIES
   addressable
   capybara
   fakeweb
+  google_maps_geocoder (~> 0.3.0)
   json (~> 1.8.1)
   nokogiri
   padrino (= 0.12.0)

--- a/app/controllers/location.rb
+++ b/app/controllers/location.rb
@@ -1,5 +1,11 @@
 HasBeen.controllers do
+
+  CACHE_SECONDS = 2505600 # 29 days
+
   layout :application
+
+  register Padrino::Cache  # includes helpers
+  enable :caching          # turns on caching
 
   get :index do
     case username
@@ -15,6 +21,23 @@ HasBeen.controllers do
       halt 404 if @traveller.nil?
       render "location/overview"
     end
+  end
+
+  get :locations_json, map: '/locations.json' do
+    halt 404 unless defined? username
+    @traveller = Travellers.find(username)
+    halt 404 if @traveller.nil?
+    content_type :json
+    locations = @traveller.locations.collect do |location|
+      begin
+        content_from_cache = cache("location_#{location}", :expires_in => CACHE_SECONDS) do
+          location.geo_data.to_json
+        end
+        JSON.parse(content_from_cache)
+      rescue RuntimeError => e
+      end
+    end
+    { locations: locations.delete_if(&:nil?) }.to_json
   end
 
   get :index, :map => "/:location" do

--- a/app/views/location/overview.erb
+++ b/app/views/location/overview.erb
@@ -19,5 +19,5 @@
   </div>
 </div>
 <div id="map" style="width:100%; height:100%"></div>
-<script>overview(<%= @traveller.locations.to_json %>);</script>
+<script>overview();</script>
 

--- a/lib/location.rb
+++ b/lib/location.rb
@@ -1,3 +1,9 @@
 class Location < String
   attr_accessor :hint
+
+  def geo_data
+    geo = GoogleMapsGeocoder.new(hint || self)
+    { name: self, lat: geo.lat, lng: geo.lng }
+  end
+
 end

--- a/public/javascripts/hasbeen.js
+++ b/public/javascripts/hasbeen.js
@@ -1,48 +1,44 @@
-var locations = [];
-
-function map() {
+function display_map(locations) {
   var bounds = new google.maps.LatLngBounds();
-  var geocoder = new google.maps.Geocoder();
   var $bar_container = $('#bar');
   var $map_container = $('#map');
   $map_container.css('margin-top', $bar_container.height());
   var map = new google.maps.Map($map_container.get(0), { disableDefaultUI: true });
-  function setup_locations() {
-    var single_location = locations.pop();
-    geocoder.geocode({ address: single_location }, function(results, status) {
-      if (status == google.maps.GeocoderStatus.OK) {
-        var marker = new google.maps.Marker({
-          position: results[0].geometry.location,
-          map: map,
-          title: single_location
-        });
-        bounds.extend(marker.getPosition());
-      }
-    });
-    locations.length ? window.setTimeout(setup_locations, 100) : map.fitBounds(bounds)
-  }
-  if(locations.length == 1) {
-    geocoder.geocode({ address: locations.pop() }, function(results, status) {
-      if (status == google.maps.GeocoderStatus.OK) {
-        map.fitBounds(results[0].geometry.viewport);
-        map.setCenter(results[0].geometry.location);
-      }
-    });
-  }
-  else {
-    google.maps.event.addDomListener(window, 'load', setup_locations);
-  }
+  jQuery.each(locations, function(index, single_location) {
+    var pos = new google.maps.LatLng(single_location.lat, single_location.lng);
+    if(locations.length > 1) {
+      var marker = new google.maps.Marker({
+        position: pos,
+        map: map,
+        title: single_location.name
+      });
+    }
+    bounds.extend(pos);
+  });
+  map.fitBounds(bounds);
 }
 
 /**
  * I've always wanted to define that function!
  */
 function goto(single_location) {
-  locations = [decodeURIComponent(single_location)];
-  map();
+  var geocoder = new google.maps.Geocoder();
+  var map = new google.maps.Map(document.getElementById('map'), { disableDefaultUI: true });
+  geocoder.geocode({ address: single_location }, function(results, status) {
+    if (status == google.maps.GeocoderStatus.OK) {
+      map.fitBounds(results[0].geometry.viewport);
+      map.setCenter(results[0].geometry.location);
+    }
+  });
 }
 
-function overview(location_list) {
-  locations = location_list;
-  map();
+function overview() {
+  $.ajax({
+    url: window.location.href + 'locations.json',
+    type: 'get',
+    dataType: 'json',
+    success: function(data, status) {
+      display_map(data.locations);
+    }
+  })
 }


### PR DESCRIPTION
This pull request addresses the issue reported in #59.

Instead of doing the geocoding client-side, the app will do it on the server side and cache the results in tmp files by using the cache feature from padrino. The cache expires after 29 days, so it complines with the google api terms, but in the most cases the cache will be dropped much earlier because heroku will respawn the dynos. In cases the api doesn't return coordinates the location will be skipped and retried on next page load.

This has been tested on heroku already and works because the cache is created in the `tmp` directory which is beside the log directory the only exemption in the heroku read-only filesystem.
