### PR TITLE
decode url encoded locations in javascript (closes #70)

### DIFF
--- a/public/javascripts/hasbeen.js
+++ b/public/javascripts/hasbeen.js
@@ -24,7 +24,7 @@ function display_map(locations) {
 function goto(single_location) {
   var geocoder = new google.maps.Geocoder();
   var map = new google.maps.Map(document.getElementById('map'), { disableDefaultUI: true });
-  geocoder.geocode({ address: single_location }, function(results, status) {
+  geocoder.geocode({ address: decodeURIComponent(single_location) }, function(results, status) {
     if (status == google.maps.GeocoderStatus.OK) {
       map.fitBounds(results[0].geometry.viewport);
       map.setCenter(results[0].geometry.location);


### PR DESCRIPTION
Seems I've broke something in my last big change :sweat_smile:. Of course we need to decode the url encoded location in the javascript again for the single location-view.

closes #70
