### PR TITLE
Remove `sensor` parameter from Google Maps script element

### DIFF
--- a/app/views/layouts/application.erb
+++ b/app/views/layouts/application.erb
@@ -6,7 +6,7 @@
     <%= stylesheet_link_tag 'custom' %>
     <%= javascript_include_tag 'http://code.jquery.com/jquery-1.11.0.min.js' %>
     <%= javascript_include_tag 'hasbeen' %>
-    <%= javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=AIzaSyAaMSg6gwxHyX9_dRb--bqCGKzeC6AS0yU&sensor=false" %>
+    <%= javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=AIzaSyAaMSg6gwxHyX9_dRb--bqCGKzeC6AS0yU" %>
     <title><%= descriptive_title %></title>
   </head>
   <body>


### PR DESCRIPTION
See #137 for more information.