### PR TITLE
Fix Dublin (it's Ireland not Ohio)

### DIFF
--- a/config/travellers/onkelhotte.yml
+++ b/config/travellers/onkelhotte.yml
@@ -11,7 +11,7 @@ hasbeen:
     - { "Billund" : "Billund, Denmark" }
     - "Bregenz"
     - "Cologne"
-    - "Dublin"
+    - { "Dublin" : "Dublin, Ireland" }
     - "Galway"
     - "Hamburg"
     - "Kilkenny"


### PR DESCRIPTION
Just noticed:

For some reason on my subdomain it looks like if I would have been in Dublin, Ohio :us: but that's not true :laughing:

![screen shot 2016-10-10 at 21 00 04](https://cloud.githubusercontent.com/assets/615777/19247689/a7891e3a-8f2c-11e6-9f03-7fb45384d832.png)

[Others](https://github.com/findoutwho/hasbeen.in/search?utf8=✓&q=dublin) might be also affected but of course I cannot tell if they not actually meant the 🇺🇸 one.