### PR TITLE
Lucas traveling in 2016

### DIFF
--- a/config/travellers/moonglum.yml
+++ b/config/travellers/moonglum.yml
@@ -11,6 +11,7 @@ hasbeen:
     - "Aberfoyle"
     - "Amsterdam"
     - "Antalya"
+    - "Arosa"
     - "Bad Oeynhausen"
     - "Ballindalloch"
     - "Barcelona"
@@ -32,9 +33,11 @@ hasbeen:
     - "Edinburgh"
     - {"Ephesus": "Ephesus, Selcuk, Turkey" }
     - "Fochabers"
+    - "Geneva"
     - "Ghent"
     - {"Goa": "Goa, India"}
     - "Grantown on Spey"
+    - "Gumpoldskirchen"
     - "Hamburg"
     - "Hanover"
     - "Heide"
@@ -58,6 +61,7 @@ hasbeen:
     - "Munich"
     - "Munster"
     - "Nuremberg"
+    - "Nordhastedt"
     - "Palo Alto"
     - "Paris"
     - "Pisa"
@@ -69,6 +73,7 @@ hasbeen:
     - "Salzburg"
     - "San Francisco"
     - "Singapore"
+    - "Sofia"
     - {"Spa": "Spa, Liege, Belgium"}
     - {"Stanford": "Stanford, California"}
     - "Stirling"


### PR DESCRIPTION
Got to step up my hasbeen.in game for 2017 – will need to write travel logs again 👍 But for last year, this has to suffice 😭 

* Berlin (30.1. – 5.2.) for microXchg
* Tondorf (6.2. – 8.2.) for yak shaving
* Munich (8.3. – 11.3.) for RubyShift (gave a talk) & vacation
* Gumpoldskirchen + Vienna (1.7. – 5.7.) for a wedding & vacation
* St. Augustin (20.8. – 21.8.) for Froscon (gave a talk)
* Geneva (31.8. – 2.9.) for innoQ Event
* Sofia (22.9. – 25.9.) for Euruko
* Tondorf (18.11. – 20.11.) for yak shaving
* Munich (22.11. – 24.11.) for work
* Arosa (14.12. – 16.12.) for innoQ Event
* Hamburg (26.12. – 30.12.) for 33c3
* Nordhastedt (30.12. – 2.1.) for vacation